### PR TITLE
Remove invalid property values

### DIFF
--- a/themes/Tokyonight-Dark-B/gtk-3.0/gtk-dark.css
+++ b/themes/Tokyonight-Dark-B/gtk-3.0/gtk-dark.css
@@ -14747,49 +14747,41 @@ scrollbar button {
 }
 
 scrollbar.vertical button.down {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }
 
 scrollbar.vertical button.down:hover {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }
 
 scrollbar.vertical button.up {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }
 
 scrollbar.vertical button.up:hover {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }
 
 scrollbar.horizontal button.down {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }
 
 scrollbar.horizontal button.down:hover {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }
 
 scrollbar.horizontal button.up {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }
 
 scrollbar.horizontal button.up:hover {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }

--- a/themes/Tokyonight-Dark-B/gtk-3.0/gtk.css
+++ b/themes/Tokyonight-Dark-B/gtk-3.0/gtk.css
@@ -14747,49 +14747,41 @@ scrollbar button {
 }
 
 scrollbar.vertical button.down {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }
 
 scrollbar.vertical button.down:hover {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }
 
 scrollbar.vertical button.up {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }
 
 scrollbar.vertical button.up:hover {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }
 
 scrollbar.horizontal button.down {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }
 
 scrollbar.horizontal button.down:hover {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }
 
 scrollbar.horizontal button.up {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }
 
 scrollbar.horizontal button.up:hover {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }

--- a/themes/Tokyonight-Dark-BL/gtk-3.0/gtk-dark.css
+++ b/themes/Tokyonight-Dark-BL/gtk-3.0/gtk-dark.css
@@ -24196,49 +24196,41 @@ scrollbar button {
 }
 
 scrollbar.vertical button.down {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }
 
 scrollbar.vertical button.down:hover {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }
 
 scrollbar.vertical button.up {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }
 
 scrollbar.vertical button.up:hover {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }
 
 scrollbar.horizontal button.down {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }
 
 scrollbar.horizontal button.down:hover {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }
 
 scrollbar.horizontal button.up {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }
 
 scrollbar.horizontal button.up:hover {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }

--- a/themes/Tokyonight-Dark-BL/gtk-3.0/gtk.css
+++ b/themes/Tokyonight-Dark-BL/gtk-3.0/gtk.css
@@ -24196,49 +24196,41 @@ scrollbar button {
 }
 
 scrollbar.vertical button.down {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }
 
 scrollbar.vertical button.down:hover {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }
 
 scrollbar.vertical button.up {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }
 
 scrollbar.vertical button.up:hover {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }
 
 scrollbar.horizontal button.down {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }
 
 scrollbar.horizontal button.down:hover {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }
 
 scrollbar.horizontal button.up {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }
 
 scrollbar.horizontal button.up:hover {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }

--- a/themes/Tokyonight_Light/gtk-3.0/gtk-dark.css
+++ b/themes/Tokyonight_Light/gtk-3.0/gtk-dark.css
@@ -14750,49 +14750,41 @@ scrollbar button {
 }
 
 scrollbar.vertical button.down {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }
 
 scrollbar.vertical button.down:hover {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }
 
 scrollbar.vertical button.up {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }
 
 scrollbar.vertical button.up:hover {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }
 
 scrollbar.horizontal button.down {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }
 
 scrollbar.horizontal button.down:hover {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }
 
 scrollbar.horizontal button.up {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }
 
 scrollbar.horizontal button.up:hover {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }

--- a/themes/Tokyonight_Light/gtk-3.0/gtk.css
+++ b/themes/Tokyonight_Light/gtk-3.0/gtk.css
@@ -14746,49 +14746,41 @@ scrollbar button {
 }
 
 scrollbar.vertical button.down {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }
 
 scrollbar.vertical button.down:hover {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }
 
 scrollbar.vertical button.up {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }
 
 scrollbar.vertical button.up:hover {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }
 
 scrollbar.horizontal button.down {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }
 
 scrollbar.horizontal button.down:hover {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }
 
 scrollbar.horizontal button.up {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }
 
 scrollbar.horizontal button.up:hover {
-  -gtk-icon-source: transparent;
   background-color: transparent;
   color: transparent;
 }


### PR DESCRIPTION
`transparent` is not a valid value for `-gtk-icon-source` ([source](https://docs.gtk.org/gtk3/css-properties.html#icon-properties)) and results in warnings when GTK tries to parse the themes.

![gtk_warnings](https://user-images.githubusercontent.com/84244762/172057923-201ccfb6-cf63-42be-919c-d789ae4d855e.png)

This PR just fixes those warnings by removing the invalid lines.