### PR TITLE
Fix Nautilus sidebar background color

### DIFF
--- a/themes/Tokyonight-Dark-B-LB/gtk-4.0/gtk-dark.css
+++ b/themes/Tokyonight-Dark-B-LB/gtk-4.0/gtk-dark.css
@@ -5896,7 +5896,8 @@ popover.entry-completion > contents {
   padding: 0;
 }
 
-.nautilus-window {
+.nautilus-window,
+.nautilus-window list {
   background-color: #1a1b26;
 }
 

--- a/themes/Tokyonight-Dark-B-LB/gtk-4.0/gtk.css
+++ b/themes/Tokyonight-Dark-B-LB/gtk-4.0/gtk.css
@@ -5896,7 +5896,8 @@ popover.entry-completion > contents {
   padding: 0;
 }
 
-.nautilus-window {
+.nautilus-window,
+.nautilus-window list {
   background-color: #1a1b26;
 }
 

--- a/themes/Tokyonight-Dark-B/gtk-4.0/gtk-dark.css
+++ b/themes/Tokyonight-Dark-B/gtk-4.0/gtk-dark.css
@@ -5969,7 +5969,8 @@ popover.entry-completion > contents {
   padding: 0;
 }
 
-.nautilus-window {
+.nautilus-window,
+.nautilus-window list {
   background-color: #1a1b26;
 }
 

--- a/themes/Tokyonight-Dark-B/gtk-4.0/gtk.css
+++ b/themes/Tokyonight-Dark-B/gtk-4.0/gtk.css
@@ -5969,7 +5969,8 @@ popover.entry-completion > contents {
   padding: 0;
 }
 
-.nautilus-window {
+.nautilus-window,
+.nautilus-window list {
   background-color: #1a1b26;
 }
 

--- a/themes/Tokyonight-Dark-BL-LB/gtk-4.0/gtk-dark.css
+++ b/themes/Tokyonight-Dark-BL-LB/gtk-4.0/gtk-dark.css
@@ -5907,7 +5907,8 @@ popover.entry-completion > contents {
   padding: 0;
 }
 
-.nautilus-window {
+.nautilus-window,
+.nautilus-window list {
   background-color: #1a1b26;
 }
 

--- a/themes/Tokyonight-Dark-BL-LB/gtk-4.0/gtk.css
+++ b/themes/Tokyonight-Dark-BL-LB/gtk-4.0/gtk.css
@@ -5907,7 +5907,8 @@ popover.entry-completion > contents {
   padding: 0;
 }
 
-.nautilus-window {
+.nautilus-window,
+.nautilus-window list {
   background-color: #1a1b26;
 }
 

--- a/themes/Tokyonight-Dark-BL/gtk-4.0/gtk-dark.css
+++ b/themes/Tokyonight-Dark-BL/gtk-4.0/gtk-dark.css
@@ -5980,7 +5980,8 @@ popover.entry-completion > contents {
   padding: 0;
 }
 
-.nautilus-window {
+.nautilus-window,
+.nautilus-window list {
   background-color: #1a1b26;
 }
 

--- a/themes/Tokyonight-Dark-BL/gtk-4.0/gtk.css
+++ b/themes/Tokyonight-Dark-BL/gtk-4.0/gtk.css
@@ -5980,7 +5980,8 @@ popover.entry-completion > contents {
   padding: 0;
 }
 
-.nautilus-window {
+.nautilus-window,
+.nautilus-window list {
   background-color: #1a1b26;
 }
 

--- a/themes/Tokyonight-Storm-B-LB/gtk-4.0/gtk-dark.css
+++ b/themes/Tokyonight-Storm-B-LB/gtk-4.0/gtk-dark.css
@@ -5896,7 +5896,8 @@ popover.entry-completion > contents {
   padding: 0;
 }
 
-.nautilus-window {
+.nautilus-window,
+.nautilus-window list {
   background-color: #24283b;
 }
 

--- a/themes/Tokyonight-Storm-B-LB/gtk-4.0/gtk.css
+++ b/themes/Tokyonight-Storm-B-LB/gtk-4.0/gtk.css
@@ -5896,7 +5896,8 @@ popover.entry-completion > contents {
   padding: 0;
 }
 
-.nautilus-window {
+.nautilus-window,
+.nautilus-window list {
   background-color: #24283b;
 }
 

--- a/themes/Tokyonight-Storm-B/gtk-4.0/gtk-dark.css
+++ b/themes/Tokyonight-Storm-B/gtk-4.0/gtk-dark.css
@@ -5969,7 +5969,8 @@ popover.entry-completion > contents {
   padding: 0;
 }
 
-.nautilus-window {
+.nautilus-window,
+.nautilus-window list {
   background-color: #24283b;
 }
 

--- a/themes/Tokyonight-Storm-B/gtk-4.0/gtk.css
+++ b/themes/Tokyonight-Storm-B/gtk-4.0/gtk.css
@@ -5969,7 +5969,8 @@ popover.entry-completion > contents {
   padding: 0;
 }
 
-.nautilus-window {
+.nautilus-window,
+.nautilus-window list {
   background-color: #24283b;
 }
 

--- a/themes/Tokyonight-Storm-BL-LB/gtk-4.0/gtk-dark.css
+++ b/themes/Tokyonight-Storm-BL-LB/gtk-4.0/gtk-dark.css
@@ -5907,7 +5907,8 @@ popover.entry-completion > contents {
   padding: 0;
 }
 
-.nautilus-window {
+.nautilus-window,
+.nautilus-window list {
   background-color: #24283b;
 }
 

--- a/themes/Tokyonight-Storm-BL-LB/gtk-4.0/gtk.css
+++ b/themes/Tokyonight-Storm-BL-LB/gtk-4.0/gtk.css
@@ -5907,7 +5907,8 @@ popover.entry-completion > contents {
   padding: 0;
 }
 
-.nautilus-window {
+.nautilus-window,
+.nautilus-window list {
   background-color: #24283b;
 }
 

--- a/themes/Tokyonight-Storm-BL/gtk-4.0/gtk-dark.css
+++ b/themes/Tokyonight-Storm-BL/gtk-4.0/gtk-dark.css
@@ -5980,7 +5980,8 @@ popover.entry-completion > contents {
   padding: 0;
 }
 
-.nautilus-window {
+.nautilus-window,
+.nautilus-window list {
   background-color: #24283b;
 }
 

--- a/themes/Tokyonight-Storm-BL/gtk-4.0/gtk.css
+++ b/themes/Tokyonight-Storm-BL/gtk-4.0/gtk.css
@@ -5980,7 +5980,8 @@ popover.entry-completion > contents {
   padding: 0;
 }
 
-.nautilus-window {
+.nautilus-window,
+.nautilus-window list {
   background-color: #24283b;
 }
 


### PR DESCRIPTION
### Nautilus sidebar background color wasn't showing correctly, fixed it with a tiny tweak.

#### Before the fix:

![nautilus_before_fix](https://github.com/Fausto-Korpsvart/Tokyo-Night-GTK-Theme/assets/107230184/1aaa6760-3044-448e-8fba-a55756b91292)

#### After the fix:

![nautilus_after_fix](https://github.com/Fausto-Korpsvart/Tokyo-Night-GTK-Theme/assets/107230184/291a80e5-32ec-40a2-be0f-7ac8b475bc3a)
